### PR TITLE
Apple審査時のInvalid privacy manifest対応

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -1,18 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array>
-		<dict/>
-	</array>
-	<key>NSPrivacyCollectedDataTypes</key>
-	<array>
-		<dict/>
-	</array>
-	<key>NSPrivacyTrackingDomains</key>
-	<array/>
-	<key>NSPrivacyTracking</key>
-	<false/>
-</dict>
+	<dict>
+		<key>NSPrivacyTracking</key>
+		<false />
+	</dict>
 </plist>


### PR DESCRIPTION
# Overview

Apple審査時のInvalid privacy manifest対応。

# Why

Appleの審査を通すため。

# How

keyに対して値が設定されていないことが原因でエラーになってると判断し、keyごと削除した。

Appleからのメールは以下。
https://tolettacats.slack.com/files/U01K8FML89Y/F0990V32Z9R/action_needed__the_uploaded_build_for_toletta_has_one_or_more_issues.

