### PR TITLE
invalid privacy manifest対応 keyの復活

### DIFF
--- a/ios/PrivacyInfo.xcprivacy
+++ b/ios/PrivacyInfo.xcprivacy
@@ -2,6 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 	<dict>
+		<key>NSPrivacyTrackingDomains</key>
+		<array />
+		<key>NSPrivacyAccessedAPITypes</key>
+		<array />
+		<key>NSPrivacyCollectedDataTypes</key>
+		<array />
 		<key>NSPrivacyTracking</key>
 		<false />
 	</dict>


### PR DESCRIPTION
# Overview

invalid privacy manifest対応

# Why

前回の修正ではAppleの審査が通らず。
同じエラーが返ってくる。

# How

ひとつ前の修正ではダメだったので[こちら](https://press.monaca.io/takuya/24330#:~:text=Copy-,%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B%20API%20%E3%82%92%E5%AE%A3%E8%A8%80%3A,-%3Ckey%3ENSPrivacyAccessedAPITypes%3C/key)のサイトを参考にkeyを復活して値に空配列を指定するように変更。

[こちら](https://github.com/ksokolovskyi-yc/flutter_app_badger)のリポジトリでも同様の修正を行なっていた。

